### PR TITLE
Add Missing EventTypes to enum

### DIFF
--- a/src/main/java/com/hellosign/sdk/resource/support/types/EventType.java
+++ b/src/main/java/com/hellosign/sdk/resource/support/types/EventType.java
@@ -40,5 +40,7 @@ public enum EventType {
     file_error,
     test,
     callback_test,
-    unknown_error
+    unknown_error,
+    sign_url_invalid,
+    signature_request_email_bounce
 }


### PR DESCRIPTION
While testing Embedded with a used URL I received a callback for with

"event_type":"sign_url_invalid"

Which then threw

`
java.lang.IllegalArgumentException: No enum constant com.hellosign.sdk.resource.support.types.EventType.sign_url_invalid
	at java.lang.Enum.valueOf(Enum.java:238)
	at com.hellosign.sdk.resource.support.types.EventType.valueOf(EventType.java:27)
	at com.hellosign.sdk.resource.Event.getType(Event.java:247)
	at com.hellosign.sdk.resource.Event.<init>(Event.java:71)
`