### PR TITLE
Rethrow HelloSignException rather than nesting it

### DIFF
--- a/src/main/java/com/hellosign/sdk/http/HttpGetRequest.java
+++ b/src/main/java/com/hellosign/sdk/http/HttpGetRequest.java
@@ -128,8 +128,10 @@ public class HttpGetRequest extends AbstractHttpRequest {
             String response = convertStreamToString(is);
             json = new JSONObject(response);
             validate(json, httpCode);
-        } catch (Exception ex) {
-            throw new HelloSignException(ex);
+        } catch (HelloSignException e) {            
+            throw e;
+        } catch (Exception e) {
+            throw new HelloSignException(e);
         }
         return json;
     }


### PR DESCRIPTION
Right now if an HelloSignException is thrown on a HTTP GET request like com.hellosign.sdk.HelloSignClient.getSignatureRequest the exception is caught by an generic Exception catch handler and chained to a new HelloSignException. 

This PR syncs up the handling with HTTP Post which specifically catches and rethrows a HelloSignException

https://github.com/HelloFax/hellosign-java-sdk/blob/v3/src/main/java/com/hellosign/sdk/http/HttpPostRequest.java#L157