### PR TITLE
Add method to extract event_message from event

### DIFF
--- a/src/main/java/com/hellosign/sdk/resource/Event.java
+++ b/src/main/java/com/hellosign/sdk/resource/Event.java
@@ -54,6 +54,7 @@ public class Event extends AbstractResource {
     public static final String EVENT_TYPE = "event_type";
     public static final String EVENT_TIME = "event_time";
     public static final String EVENT_HASH = "event_hash";
+    public static final String EVENT_MESSAGE = "event_message";
 
     public static final String HASH_ALGORITHM = "HmacSHA256";
 
@@ -146,6 +147,23 @@ public class Event extends AbstractResource {
      */
     public Date getEventDate() {
         return getDate(EVENT_TIME);
+    }
+    
+    /**
+     * Returns the message if any from the event
+     * @return String
+     * @throws HelloSignException thrown if there is a problem parsing
+     * the backing JSONObject. 
+     */
+    public String getEventMessage() throws HelloSignException{
+        JSONObject metadata = (JSONObject) get(EVENT_METADATA);
+        String eventMessage = null;
+        try {
+            eventMessage = metadata.getString(EVENT_MESSAGE);
+        } catch (JSONException ex) {
+            throw new HelloSignException(ex);
+        }
+        return eventMessage;
     }
 
     /**


### PR DESCRIPTION
Currently there is not a means to get an event message from an event.

This can be found in an event_metadata on an signature_request_invalid event

```"event_metadata":{"related_signature_id":null,"reported_for_account_id":null,"reported_for_app_id":"xxxxxxx","event_message":"Text tags error: No signers in text tags"}}```